### PR TITLE
Move postinstall to separate script. Alter script to run on windows.

### DIFF
--- a/npm-postinstall.js
+++ b/npm-postinstall.js
@@ -1,0 +1,9 @@
+var exec = require('child_process').exec;
+var sys = require('sys');
+var envSep = ~process.platform.indexOf('win') ? ';' : ':';
+
+process.env.PATH = 'bin' + envSep + process.env.PATH;
+
+exec('bower install && bundle install --binstubs && grunt githooks', function(err, stdout, stderr){
+  sys.puts(stdout);
+});

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "PROJECT_NAME",
   "version": "0.0.1",
   "scripts": {
-    "postinstall": "export PATH=bin:$PATH && bower install && bundle install --binstubs && grunt githooks"
+    "postinstall": "node npm-postinstall.js"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Added a separate post-install script that is run within node. Does pretty much the same thing as the previous form, except without the dependence on the export env set. Was failing on windows.