### PR TITLE
Fix font pathing. Change src/dest to use config props.

### DIFF
--- a/build/config/copy.js
+++ b/build/config/copy.js
@@ -25,13 +25,13 @@ module.exports = function(grunt) {
       files: [
         {
           expand: true,
-          cwd: './source',
+          cwd: config.root,
           src: [
             'robots.txt',
             'favicon.ico',
-            'css/fonts/*/*'
+            'css/fonts/**/*'
           ],
-          dest: './dist/'
+          dest: config.dist
         }
       ]
     }


### PR DESCRIPTION
Font pathing was missing an extra star for directory globbing.

Dist src and dest values should look at the global config values.