### PR TITLE
Compass dist task should output to the dist css dir.

### DIFF
--- a/build/config/compass.js
+++ b/build/config/compass.js
@@ -26,10 +26,11 @@ module.exports = function(grunt) {
     dev: {},
 
     dist: {
-     options: {
-       debugInfo: false,
-       outputStyle: 'compressed'
-     }
+      options: {
+        debugInfo: false,
+        outputStyle: 'compressed',
+        cssDir: config.distCSS
+      }
     }
   };
 };


### PR DESCRIPTION
Changed compass:dist to output to the config.distCSS dir, instead of the default.

Also fixed spacing.